### PR TITLE
Fix MpZonedDateTime year string conversion

### DIFF
--- a/commonmp/src/commonMain/kotlin/common/datetime/MpZonedDateTime.kt
+++ b/commonmp/src/commonMain/kotlin/common/datetime/MpZonedDateTime.kt
@@ -209,7 +209,7 @@ data class MpZonedDateTime private constructor(
 
         val yearStr = when {
             year > 9999 -> "+$year"
-            else -> "$year"
+            else -> year.pad(4)
         }
 
         return "$yearStr-${monthNumber.pad()}-${dayOfMonth.pad()}T" +

--- a/commonmp/src/commonTest/kotlin/common/datetime/MpZonedDateTimeSpec.kt
+++ b/commonmp/src/commonTest/kotlin/common/datetime/MpZonedDateTimeSpec.kt
@@ -163,6 +163,21 @@ class MpZonedDateTimeSpec : StringSpec({
 
         MpZonedDateTime.parse("2022-04-05T00:00:00", TimeZone.of("Europe/Berlin"))
             .toIsoString() shouldBe "2022-04-05T02:00:00.000[Europe/Berlin]"
+
+        MpZonedDateTime.of(
+            datetime = MpLocalDateTime.of(year = 2, month = 3, day = 4),
+            timezone = TimeZone.of("UTC")
+        ).toIsoString() shouldBe "0002-03-04T00:00:00.000Z"
+
+        MpZonedDateTime.of(
+            datetime = MpLocalDateTime.of(year = 232, month = 12, day = 2),
+            timezone = TimeZone.of("UTC")
+        ).toIsoString() shouldBe "0232-12-02T00:00:00.000Z"
+
+        MpZonedDateTime.of(
+            datetime = MpLocalDateTime.of(year = 39, month = 11, day = 25, hour = 15, minute = 44),
+            timezone = TimeZone.of("Europe/Berlin")
+        ).toIsoString() shouldBe "0039-11-25T15:44:00.000[Europe/Berlin]"
     }
 
     "parse - toIsoString - round trip" {

--- a/gradle.properties
+++ b/gradle.properties
@@ -11,7 +11,7 @@ org.gradle.parallel=false
 # ###############################################################################################
 GROUP=io.peekandpoke.ultra
 #VERSION_NAME=0.59.3.1.RC1-SNAPSHOT
-VERSION_NAME=0.70.1
+VERSION_NAME=0.70.2
 # ###############################################################################################
 #
 # Publishing https://github.com/vanniktech/gradle-maven-publish-plugin


### PR DESCRIPTION
Fix MpZonedDateTime year string conversion by adding 4 pad when turning into iso string which previously caused issues when year is lower than 1000.